### PR TITLE
Improved multithread demos with more thread tests

### DIFF
--- a/matlab/demos/demo_filter_image_threads.m
+++ b/matlab/demos/demo_filter_image_threads.m
@@ -3,8 +3,8 @@
 clear all
 close all
 
-% WRITE HERE YOUR NUMBER OF THREADS
-threads = 2;
+% WRITE HERE YOUR NUMBER OF THREADS TO TEST
+THREADS = [1 2 3 4 5 6 7 8];
 
 % Load image
 X = rgb2gray(imread('QRbig.png'));
@@ -13,21 +13,21 @@ X = rgb2gray(imread('QRbig.png'));
 noiseLevel = 0.2;
 N = double(imnoise(X,'gaussian',0,noiseLevel));
 
-% Filter using 1 thread
-lambda=50;
-disp('Filtering image...');
-tic;
-F = TV(N,lambda);
-toc;
+% Iterate over number of threads
+times = zeros(size(THREADS));
+idx = 1;
+for nthreads = THREADS
+    % Filter image
+    lambda=50;
+    disp(['Filtering image with ', num2str(nthreads), ' threads ...']);
+    tic;
+    F = TV(N, lambda, 1, nthreads);
+    times(idx) = toc;
+    disp([num2str(toc), ' seconds']);
+    idx = idx + 1;
+end
 
-% Now filter using several threads
-lambda=50;
-disp('Filtering image...');
-tic;
-F = TV(N,lambda,1,threads);
-toc;
-
-% Plot results
+% Plot filtering results
 figure();
 subplot(1,3,1);
 imshow(X);
@@ -39,3 +39,10 @@ subplot(1,3,3);
 imshow(uint8(F));
 title('Filtered');
 
+% Plot measured times
+figure();
+bar(THREADS, times);
+xlabel('Threads','FontSize',20);
+ylabel('Time (s)','FontSize',20);
+title('Filtering times for increasing threads','FontSize',25);
+set(gca,'FontSize',17);

--- a/prox_tv/demos/demo_filter_image_threads.py
+++ b/prox_tv/demos/demo_filter_image_threads.py
@@ -7,8 +7,8 @@ import time
 import skimage as ski
 from skimage import data, io, filters, color, util
 
-# WRITE HERE YOUR NUMBER OF THREADS
-threads = 2
+# WRITE HERE YOUR NUMBER OF THREADS TO TEST
+THREADS = [1, 2, 3, 4, 5, 6, 7, 8];
 
 # Load image
 X = io.imread('QRbig.png')
@@ -19,22 +19,18 @@ X = color.rgb2gray(X)
 noiseLevel = 0.2
 N = util.random_noise(X, mode='gaussian', var=noiseLevel)
 
-# Filter using 1 thread
-lam=50./255.;
-print('Filtering image with 1 thread...');
-start = time.time()
-F = ptv.tv1_2d(N, lam)
-end = time.time()
-print('Elapsed time ' + str(end-start))
+# Iterate over number of threads
+lam=50./255.
+times = []
+for threads in THREADS:
+    print('Filtering image with ' + str(threads) + ' threads...');
+    start = time.time()
+    F = ptv.tv1_2d(N, lam, n_threads=threads)
+    end = time.time()
+    times.append(end-start)
+    print('Elapsed time ' + str(end-start))
 
-# Now filter using several threads
-print('Filtering image with ' + str(threads) + ' threads...');
-start = time.time()
-F = ptv.tv1_2d(N, lam, n_threads=threads)
-end = time.time()
-print('Elapsed time ' + str(end-start))
-
-# Plot results
+# Plot filtering results
 plt.subplot(1, 3, 1)
 io.imshow(X)
 plt.xlabel('Original')
@@ -49,4 +45,12 @@ io.imshow(F)
 plt.xlabel('Filtered')
 
 show()
+
+# Plot timing results
+fig, ax = plt.subplots()
+ax.bar(THREADS, times, color = 'g')
+ax.set_xlabel('Number of threads')
+ax.set_ylabel('Time (s)')
+ax.set_title('Filtering times for increasing threads')
+plt.show()
 


### PR DESCRIPTION
This merge improves the multithreading demos by allowing test for an arbitrary number of threads. A barplot is displayed after the tests to show running times per number of threads. Changes have been done both in Matlab and Python implementations.
