### PR TITLE
FIX: compilation for OSX

### DIFF
--- a/prox_tv/prox_tv_build.py
+++ b/prox_tv/prox_tv_build.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+from sys import platform as _platform
 
 from cffi import FFI
 
@@ -74,6 +75,19 @@ sources = [os.path.join('src', fname) for fname in (
     'TVL2opt.cpp', 'TVLPopt.cpp', 'TVNDopt.cpp', 'utils.cpp'
 )]
 
+extra_compile_args = []
+extra_link_args = []
+if _platform == 'darwin':
+    # if openblas was installed by homerew is present use this for lapacke.h
+    if os.path.exists('/usr/local/opt/openblas/include'):
+        extra_compile_args.append('-I/usr/local/opt/openblas/include')
+else:
+    # OSX clang does not (yet) support openmp, so don't add it to compile
+    # args
+    extra_compile_args.append('-fopenmp')
+    extra_link_args.append('-fopenmp')
+
+
 ffi.set_source(
     '_prox_tv',
     """
@@ -95,8 +109,8 @@ ffi.set_source(
     """,
     sources=sources,
     define_macros=[('NOMATLAB', 1)],
-    extra_compile_args=['-fopenmp'],
-    extra_link_args=['-fopenmp'],
+    extra_compile_args=extra_compile_args,
+    extra_link_args=extra_link_args,
     libraries=['lapack']
 )
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     long_description="proxTV is a toolbox implementing blazing fast implementations of Total Variation proximity operators. While the core algorithms are implemented in C to achieve high efficiency, Matlab and Python interfaces are provided for ease of use. The library provides efficient solvers for a variety of Total Variation proximity problems, with address input signals of any dimensionality (1d, images, video, ...) and different norms to apply in the Total Variation term.",
     packages=['prox_tv'],
     install_requires=[
-        'numpy',
+        'numpy>=1.6.2',
         'cffi>=1.0.0',
     ],
     setup_requires=[


### PR DESCRIPTION
Added the path to find lapacke.h (at least for those that have openblas
installed via homebrew).

Also, I added a minimal version of numpy to setup.py as otherwise
it was forcing me to re-compile numpy although I have a reasonable
recent one). The exact number is the latests numpy supported by
the current scipy development version (I thought this would be
a reasonable choice).
