### PR TITLE
Added accelerated Chambolle-Pock for 2D TV, though with poor results

### DIFF
--- a/prox_tv/__init__.py
+++ b/prox_tv/__init__.py
@@ -314,9 +314,10 @@ def tv1_2d(x, w, n_threads=1, max_iters=0, method='dr'):
 
         * ``'dr'`` - Douglas Rachford splitting.
         * ``'pd'`` - Proximal Dykstra splitting.
-        * ``'yang'`` - Yang's algorithm.
-        * ``'condat'`` - Condat's gradient.
-        * ``'chambolle-pock'`` - Chambolle-Pock's gradient.
+        * ``'yang'`` - Yang's splitting (ADMM).
+        * ``'condat'`` - Condat's splitting.
+        * ``'chambolle-pock'`` - Chambolle-Pock's splitting.
+        * ``'chambolle-pock-acc'`` - (accelerated) Chambolle-Pock's splitting.
 
     n_threads : int
         Number of threads, used only for Proximal Dykstra
@@ -328,7 +329,8 @@ def tv1_2d(x, w, n_threads=1, max_iters=0, method='dr'):
         The solution of the optimization problem.
     """
     assert w >= 0
-    assert method in ('dr', 'pd', 'yang', 'condat', 'chambolle-pock')
+    assert method in ('dr', 'pd', 'yang', 'condat', 'chambolle-pock', 
+                      'chambolle-pock-acc')
     x = np.asfortranarray(x, dtype='float64')
     w = force_float_scalar(w)
     y = np.asfortranarray(np.zeros(x.shape))
@@ -342,7 +344,12 @@ def tv1_2d(x, w, n_threads=1, max_iters=0, method='dr'):
         _call(lib.PD2_TV, x, (w, w), (1, 1), (1, 2), y, info, x.shape, 2, 2,
               n_threads, max_iters)
     else:
-        algorithm = 0 if method == 'condat' else 1
+        variants = {
+            'condat' : 0,
+            'chambolle-pock' : 1,
+            'chambolle-pock-acc' : 2
+        }
+        algorithm = variants[method]
         _call(lib.CondatChambollePock2_TV,
               x.shape[0], x.shape[1], x, w, y, algorithm, max_iters, info)
 

--- a/prox_tv/prox_tv_test.py
+++ b/prox_tv/prox_tv_test.py
@@ -85,7 +85,8 @@ def test_tv1_2d():
         w_cols = w * np.ones((rows-1, cols))
         w_rows = w * np.ones((rows, cols-1))
         solutions.append(tv1w_2d(x, w_cols, w_rows, max_iters=5000))
-        for i in range(1, len(solutions)):
+        for i in range(0, len(solutions)):
+            print('Method', methods[i % len(methods)], 'solution is', solutions[i])
             assert np.allclose(solutions[i], solutions[0], atol=1e-3)
 
 


### PR DESCRIPTION
Implemented Algorithm 2 of the paper "A first-order primal-dual algorithm for convex problems
with applications to imaging" by Antonin Chambolle and Thomas Pock, which is a FISTA-like accelerated variant of the already implemented Chambolle-Pock method. This variant, however, does not pass the accuracy tests. It is nevertheless implemented for comparison purposes.